### PR TITLE
Add runnable version for lane extraction

### DIFF
--- a/lane_extraction/CMakeLists.txt
+++ b/lane_extraction/CMakeLists.txt
@@ -1,0 +1,63 @@
+cmake_minimum_required(VERSION 3.10)
+project(lane_extraction)
+
+add_compile_options(-std=c++11)
+
+find_package(catkin REQUIRED COMPONENTS
+  cv_bridge
+  image_transport
+  roscpp
+  sensor_msgs
+  ssdf_msgs
+)
+
+find_package(OpenCV REQUIRED)
+
+include_directories(${OpenCV_INCLUDE_DIRS})
+
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS roscpp ssdf_msgs
+)
+
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_library(${PROJECT_NAME}
+  src/${PROJECT_NAME}/lane_extraction.cpp
+  src/${PROJECT_NAME}/window_extractor.cpp
+  src/${PROJECT_NAME}/utils.cpp
+)
+
+add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+add_executable(${PROJECT_NAME}_node src/lane_extraction_node.cpp)
+
+target_link_libraries(
+  ${PROJECT_NAME}_node
+  ${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+  ${OpenCV_LIBS}
+  ${Boost_LIBRARIES}
+)
+
+add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+install(TARGETS ${PROJECT_NAME}_node
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)
+
+install(DIRECTORY include/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN ".svn" EXCLUDE
+)

--- a/lane_extraction/README.md
+++ b/lane_extraction/README.md
@@ -3,5 +3,34 @@
 This package perform lane detection
 
 
-## Installation
+# Installation
 
+Updating...
+
+
+# Package's inputs/outputs
+
+## Publishing topics
+
+This package will publish to the topic set by `~pub_lane_topic` argument. Its type is `ssdf_msgs/Lane`.
+Please have a look on `ssdf-msgs` repository for more detail.
+
+## Subscribing topics
+
+It depends on the implementation used in this class. Currently, we only support sliding window algorithm.
+However, it might be updated in the future.
+
+1. Sliding window
+
+   a lane line segmentation image published on `~sub_laneseg`. The transport hint `compressed` is used.
+
+1. Updating...
+
+# Running
+
+For example, if we want to run lane extraction on lane line segmentation images published on `/lane_seg/compressed` topic,
+and we want to return lane parameters on `/lane` topic using `compressed` image transport, we could run the command as follow.
+
+```
+rosrun lane_extraction lane_extraction_node _image_transport:=compressed _sub_laneseg:=/lane_seg _pub_lane_topic:=/lane
+```

--- a/lane_extraction/README.md
+++ b/lane_extraction/README.md
@@ -1,0 +1,7 @@
+# Lane Detection
+
+This package perform lane detection
+
+
+## Installation
+

--- a/lane_extraction/include/lane_extraction/interface.h
+++ b/lane_extraction/include/lane_extraction/interface.h
@@ -5,10 +5,30 @@
 typedef std::vector<cv::Point2i> LanePoints;
 typedef std::vector<double> LaneParams;
 
+/**
+ * @brief an interface for extractor classes
+ */
 class IExtractorImpl
 {
 public:
+    /**
+     * @brief Update method. This will be called every loop by LaneExtractor class
+     *
+     * The main purpose of this method is to update its internal state, i.e. update lane parameters
+     */
     virtual void update() = 0;
+
+    /**
+     * @brief Get the left lane's parameters
+     * It's up to you to define the number of parameters
+     * @return line parameters
+     */
     virtual LaneParams getLeftParams() const = 0;
+
+    /**
+     * @brief Get the right lane's parameters
+     * It's up to you to define the number of parameters
+     * @return line parameters
+     */
     virtual LaneParams getRightParams() const = 0;
 };

--- a/lane_extraction/include/lane_extraction/interface.h
+++ b/lane_extraction/include/lane_extraction/interface.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <vector>
+#include <opencv2/core.hpp>
+
+typedef std::vector<cv::Point2i> LanePoints;
+typedef std::vector<double> LaneParams;
+
+class IExtractorImpl
+{
+public:
+    virtual void update() = 0;
+    virtual LaneParams getLeftParams() const = 0;
+    virtual LaneParams getRightParams() const = 0;
+};

--- a/lane_extraction/include/lane_extraction/lane_extraction.h
+++ b/lane_extraction/include/lane_extraction/lane_extraction.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <memory>
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <std_msgs/Float64MultiArray.h>
+#include "lane_extraction/interface.h"
+
+class IExtractorImpl;
+
+/**
+ * @class LaneExtractor
+ * @brief Class to run Lane detection using variety of implementation.
+ */
+class LaneExtractor
+{
+public:
+    LaneExtractor();
+    ~LaneExtractor();
+
+    void run();
+
+private:
+    const size_t QUEUE_SIZE = 10;
+    const size_t PUBLISH_RATE = 15;
+
+    size_t _subscriberCount;
+
+    std::shared_ptr<IExtractorImpl> detectImpl;
+    ros::NodeHandle _nh;
+    ros::Publisher _lanePub;
+};

--- a/lane_extraction/include/lane_extraction/utils.h
+++ b/lane_extraction/include/lane_extraction/utils.h
@@ -15,6 +15,6 @@
  * @return the parameters [a_0, a_1, ..., a_n]
  */
 LaneParams polyfit(const LanePoints &points, size_t degree, LanePoints *refittedPoints = nullptr);
-void evalPoly(LaneParams &params, LanePoints &points);
+void evalPoly(const LaneParams &params, LanePoints &points);
 
 cv::Mat birdviewTransformation(const cv::Mat &src, int birdwidth, int birdheight, int skyline, int offsetLeft, int offsetRight, cv::Mat &returnM);

--- a/lane_extraction/include/lane_extraction/utils.h
+++ b/lane_extraction/include/lane_extraction/utils.h
@@ -1,0 +1,20 @@
+#include "lane_extraction/interface.h"
+
+/** 
+ * @brief Polynomial fitting a line through the given points
+ *
+ * The line formula would be
+ * x = a_0 + a_1 y + a_2 y^2 + ... + a_n y^n
+ * 
+ * For example, with degree = 2, the fitting formulas should be a parabol:
+ * x = a_0 + a_1 y + a_2 y^2
+ *
+ * @param points the points to fit
+ * @param degree the degree of the formula
+ * @param refittedPoints points will be refitted using the computed parameters. Pass nullptr to avoid refitting.
+ * @return the parameters [a_0, a_1, ..., a_n]
+ */
+LaneParams polyfit(const LanePoints &points, size_t degree, LanePoints *refittedPoints = nullptr);
+void evalPoly(LaneParams &params, LanePoints &points);
+
+cv::Mat birdviewTransformation(const cv::Mat &src, int birdwidth, int birdheight, int skyline, int offsetLeft, int offsetRight, cv::Mat &returnM);

--- a/lane_extraction/include/lane_extraction/utils.h
+++ b/lane_extraction/include/lane_extraction/utils.h
@@ -1,3 +1,5 @@
+#include <utility>
+#include <opencv2/core.hpp>
 #include "lane_extraction/interface.h"
 
 /** 
@@ -31,4 +33,15 @@ LaneParams polyfit(const LanePoints &points, size_t degree, LanePoints *refitted
  */
 void evalPoly(const LaneParams &params, LanePoints &points);
 
-cv::Mat birdviewTransformation(const cv::Mat &src, int birdwidth, int birdheight, int skyline, int offsetLeft, int offsetRight, cv::Mat &returnM);
+/**
+ * @brief Birdview Transformation or Top-down transformation using warp persective transform
+ * @param src The image to convert
+ * @param birdwidth the width of the birdview image
+ * @param birdheight the height of the birdview image
+ * @param skyline the \f$y\f$ value indicating how far it can look
+ * @param offsetLeft the offset of the bottom left
+ * @param offsetRight the offset of the bottom right
+ * @return a pair of birdview image and birdview transformation matrix
+ */
+std::pair<cv::Mat, cv::Mat> birdviewTransformation(const cv::Mat &src, int birdwidth, int birdheight,
+                                                   int skyline, int offsetLeft, int offsetRight);

--- a/lane_extraction/include/lane_extraction/utils.h
+++ b/lane_extraction/include/lane_extraction/utils.h
@@ -4,17 +4,31 @@
  * @brief Polynomial fitting a line through the given points
  *
  * The line formula would be
- * x = a_0 + a_1 y + a_2 y^2 + ... + a_n y^n
+ * \f[x = a_0 + a_1 y + a_2 y^2 + ... + a_n y^n\f]
  * 
  * For example, with degree = 2, the fitting formulas should be a parabol:
- * x = a_0 + a_1 y + a_2 y^2
+ * \f[x = a_0 + a_1 y + a_2 y^2\f]
  *
  * @param points the points to fit
  * @param degree the degree of the formula
  * @param refittedPoints points will be refitted using the computed parameters. Pass nullptr to avoid refitting.
- * @return the parameters [a_0, a_1, ..., a_n]
+ * @return the parameters \f$[a_0, a_1, ..., a_n]\f$
  */
 LaneParams polyfit(const LanePoints &points, size_t degree, LanePoints *refittedPoints = nullptr);
+
+/**
+ * @brief Polynomial computing through the given points
+ *
+ * The line formula would be
+ * \f[ x = a_0 + a_1 y + a_2 y^2 + ... + a_n y^n \f]
+ *
+ * For example, with degree = 2, the fitting formulas should be a parabol:
+ * \f[ x = a_0 + a_1 y + a_2 y^2 \f]
+ *
+ * @param params the line parameters \f$[a_0, a_1, ..., a_n]\f$
+ * @param points the points to eval. This function will compute and modify inplace
+ * the \f$x\f$ attribute of the point given its \f$y\f$
+ */
 void evalPoly(const LaneParams &params, LanePoints &points);
 
 cv::Mat birdviewTransformation(const cv::Mat &src, int birdwidth, int birdheight, int skyline, int offsetLeft, int offsetRight, cv::Mat &returnM);

--- a/lane_extraction/include/lane_extraction/window_extractor.h
+++ b/lane_extraction/include/lane_extraction/window_extractor.h
@@ -1,0 +1,158 @@
+#pragma once
+#include <vector>
+#include <image_transport/image_transport.h>
+#include <ros/ros.h>
+#include <opencv2/core.hpp>
+#include "lane_extraction/interface.h"
+
+class LaneLine
+{
+public:
+    void update(const cv::Mat &birdview);
+    void detect();
+    void track();
+
+    inline LaneParams getParams() const
+    {
+        return this->params;
+    }
+
+    inline cv::Mat getBirdviewImage() const
+    {
+        return this->birdview;
+    }
+
+    inline cv::Rect getBirdviewRect() const
+    {
+        return cv::Rect2i(0, 0, this->birdview.cols - 1, this->birdview.rows - 1);
+    }
+
+    inline bool isFound() const
+    {
+        return !this->points.empty();
+    }
+
+    LanePoints getPoints() const
+    {
+        return this->points;
+    }
+
+    virtual std::string getName() const = 0;
+    virtual cv::Scalar getLaneColor() const = 0;
+    virtual cv::Rect getDetectBeginPointRegion() const = 0;
+
+protected:
+    virtual cv::Point2f calcPerpendicular(const cv::Point2i &point) const = 0;
+    bool findPointInWindow(const cv::Mat &roi, cv::Point &outPoint, int &outVal) const;
+    bool updateNewCenter(const cv::Mat &region, cv::Point &center, int *const nonZeroValue) const;
+    bool findBeginPoint(cv::Point &returnPoint) const;
+    std::vector<cv::Point> findPoints(const cv::Point &beginPoint, int direct) const;
+
+private:
+    cv::Mat birdview;
+    LanePoints points;
+    LaneParams params;
+
+    const bool IS_REFIT = true;
+    const size_t POLY_FIT_DEGREE = 3;
+    const size_t MAX_NON_ZERO_THRESHOLD = 10;
+    const size_t MIN_POINT_TRACK = 5;
+    const size_t MIN_POINT_DETECT = 5;
+    const u_short H_TRACKING = 16;
+    const u_short W_TRACKING = 25;
+    const size_t N_BINS = 10;
+
+    int confident_score = -1;
+    int offsetX = 0;
+    int width = 160;
+};
+
+class LeftLane : public LaneLine
+{
+public:
+    virtual cv::Scalar getLaneColor() const override
+    {
+        return cv::Scalar{0, 255, 0}; // Green
+    }
+
+    cv::Rect getDetectBeginPointRegion() const
+    {
+        const auto &&birdview = this->getBirdviewImage();
+        return cv::Rect{0, 0, birdview.cols / 2, birdview.rows};
+    }
+
+    virtual cv::Point2f calcPerpendicular(const cv::Point2i &point) const override
+    {
+        cv::Point2f norm = point / cv::norm(point);
+        cv::Point2f perpendicular{norm.y, -norm.x};
+        return perpendicular;
+    }
+
+    virtual std::string getName() const override
+    {
+        return "Left";
+    }
+};
+
+class RightLane : public LaneLine
+{
+public:
+    virtual cv::Scalar getLaneColor() const override
+    {
+        return cv::Scalar{255, 0, 0}; // Blue
+    }
+
+    virtual cv::Rect getDetectBeginPointRegion() const override
+    {
+        const auto &&birdview = this->getBirdviewImage();
+        return cv::Rect{birdview.cols / 2, 0, birdview.cols / 2, birdview.rows};
+    }
+
+    virtual cv::Point2f calcPerpendicular(const cv::Point2i &point) const override
+    {
+        cv::Point2f norm = point / cv::norm(point);
+        cv::Point2f perpendicular{-norm.y, norm.x};
+        return perpendicular;
+    }
+
+    virtual std::string getName() const override
+    {
+        return "Right";
+    }
+};
+
+class WindowExtractImpl
+    : public IExtractorImpl
+{
+public:
+    WindowExtractImpl();
+
+    virtual void update() override;
+
+    virtual LaneParams getLeftParams() const override
+    {
+        return this->left.getParams();
+    }
+    virtual LaneParams getRightParams() const override
+    {
+        return this->right.getParams();
+    }
+
+private:
+    LeftLane left;
+    RightLane right;
+    cv::Mat _laneSegImage;
+
+    // Bird view configuration
+    int dropTop = 0;
+    int offsetLeft = 85;
+    int offsetRight = 85;
+    int birdwidth = 224;
+    int birdheight = 224;
+    int skyline = 135;
+
+private:
+    ros::NodeHandle _nh;
+    image_transport::ImageTransport _imageTransport;
+    image_transport::Subscriber _laneSegSub;
+};

--- a/lane_extraction/include/lane_extraction/window_extractor.h
+++ b/lane_extraction/include/lane_extraction/window_extractor.h
@@ -8,7 +8,7 @@
 class LaneLine
 {
 public:
-    void update(const cv::Mat &birdview);
+    void update(const cv::Mat &lineImage);
     void detect();
     void track();
 
@@ -17,14 +17,14 @@ public:
         return this->params;
     }
 
-    inline cv::Mat getBirdviewImage() const
+    inline cv::Mat getLineImage() const
     {
-        return this->birdview;
+        return this->lineImage;
     }
 
     inline cv::Rect getBirdviewRect() const
     {
-        return cv::Rect2i(0, 0, this->birdview.cols - 1, this->birdview.rows - 1);
+        return cv::Rect2i(0, 0, this->lineImage.cols - 1, this->lineImage.rows - 1);
     }
 
     inline bool isFound() const
@@ -49,7 +49,7 @@ protected:
     std::vector<cv::Point> findPoints(const cv::Point &beginPoint, int direct) const;
 
 private:
-    cv::Mat birdview;
+    cv::Mat lineImage;
     LanePoints points;
     LaneParams params;
 
@@ -77,8 +77,8 @@ public:
 
     cv::Rect getDetectBeginPointRegion() const
     {
-        const auto &&birdview = this->getBirdviewImage();
-        return cv::Rect{0, 0, birdview.cols / 2, birdview.rows};
+        const auto &&lineImage = this->getLineImage();
+        return cv::Rect{0, 0, lineImage.cols / 2, lineImage.rows};
     }
 
     virtual cv::Point2f calcPerpendicular(const cv::Point2i &point) const override
@@ -104,8 +104,8 @@ public:
 
     virtual cv::Rect getDetectBeginPointRegion() const override
     {
-        const auto &&birdview = this->getBirdviewImage();
-        return cv::Rect{birdview.cols / 2, 0, birdview.cols / 2, birdview.rows};
+        const auto &&lineImage = this->getLineImage();
+        return cv::Rect{lineImage.cols / 2, 0, lineImage.cols / 2, lineImage.rows};
     }
 
     virtual cv::Point2f calcPerpendicular(const cv::Point2i &point) const override

--- a/lane_extraction/include/lane_extraction/window_extractor.h
+++ b/lane_extraction/include/lane_extraction/window_extractor.h
@@ -144,6 +144,7 @@ private:
     cv::Mat _laneSegImage;
 
     // Bird view configuration
+    const bool IS_USE_BIRDVIEW = true;
     int dropTop = 0;
     int offsetLeft = 85;
     int offsetRight = 85;

--- a/lane_extraction/package.xml
+++ b/lane_extraction/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>lane_extraction</name>
+  <version>0.1.0</version>
+  <description>The lane_extraction package</description>
+
+  <author email="ssdf@todo.com">SSDF Team</author>
+  <maintainer email="ssdf@todo.com">SSDF Team</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>roscpp</depend>
+  <depend>cv_bridge</depend>
+  <depend>ssdf_msgs</depend>
+  <depend>image_transport</depend>
+  <depend>sensor_msgs</depend>
+
+</package>

--- a/lane_extraction/src/lane_extraction/lane_extraction.cpp
+++ b/lane_extraction/src/lane_extraction/lane_extraction.cpp
@@ -1,0 +1,58 @@
+#include "lane_extraction/lane_extraction.h"
+#include "lane_extraction/window_extractor.h"
+#include "ssdf_msgs/Lane.h"
+#include <opencv2/highgui.hpp>
+
+LaneExtractor::LaneExtractor()
+    : _subscriberCount{0}
+{
+    std::string lanePubTopic;
+    ROS_ASSERT(ros::param::get("~pub_lane_topic", lanePubTopic));
+
+    this->_lanePub = _nh.advertise<ssdf_msgs::Lane>(
+        lanePubTopic,
+        QUEUE_SIZE,
+        [this](const ros::SingleSubscriberPublisher &sub)
+        {
+            ROS_INFO_STREAM("New subscriber from " << sub.getSubscriberName());
+            this->_subscriberCount++;
+        },
+        [this](const ros::SingleSubscriberPublisher &sub)
+        {
+            ROS_INFO_STREAM("Disconnect from subscriber " << sub.getSubscriberName());
+            this->_subscriberCount--;
+        });
+
+    // TODO: switch between detector
+    detectImpl = std::make_shared<WindowExtractImpl>();
+}
+
+LaneExtractor::~LaneExtractor()
+{
+    cv::destroyAllWindows();
+}
+
+void LaneExtractor::run()
+{
+    ssdf_msgs::Lane msg;
+    std::vector<double> leftParams;
+    std::vector<double> rightParams;
+    ros::Rate publishRate{static_cast<double>(PUBLISH_RATE)};
+
+    while (_nh.ok())
+    {
+        ros::spinOnce();
+        detectImpl->update();
+
+        if (this->_subscriberCount > 0)
+        {
+            const LaneParams &leftParams = detectImpl->getLeftParams();
+            const LaneParams &rightParams = detectImpl->getRightParams();
+            msg.left = leftParams;
+            msg.right = rightParams;
+
+            this->_lanePub.publish(msg);
+        }
+        publishRate.sleep();
+    }
+}

--- a/lane_extraction/src/lane_extraction/utils.cpp
+++ b/lane_extraction/src/lane_extraction/utils.cpp
@@ -45,7 +45,7 @@ LaneParams polyfit(const LanePoints &points, size_t degree, LanePoints *refitted
     return params;
 }
 
-void evalPoly(LaneParams &params, LanePoints &points)
+void evalPoly(const LaneParams &params, LanePoints &points)
 {
     for (auto &point : points)
     {

--- a/lane_extraction/src/lane_extraction/utils.cpp
+++ b/lane_extraction/src/lane_extraction/utils.cpp
@@ -57,7 +57,8 @@ void evalPoly(const LaneParams &params, LanePoints &points)
     }
 }
 
-cv::Mat birdviewTransformation(const cv::Mat &src, int birdwidth, int birdheight, int skyline, int offsetLeft, int offsetRight, cv::Mat &returnM)
+std::pair<cv::Mat, cv::Mat> birdviewTransformation(const cv::Mat &src, int birdwidth, int birdheight,
+                                                   int skyline, int offsetLeft, int offsetRight)
 {
     int W = src.cols;
     int H = src.rows;
@@ -74,9 +75,8 @@ cv::Mat birdviewTransformation(const cv::Mat &src, int birdwidth, int birdheight
         cv::Point(offsetLeft, H - 1),
         cv::Point(W - offsetRight, H - 1)};
 
-    returnM = cv::getPerspectiveTransform(inQuad, outQuad);
+    cv::Mat M = cv::getPerspectiveTransform(inQuad, outQuad);
     cv::Mat resultBirdview(birdheight, birdwidth, src.type());
-    cv::warpPerspective(src, resultBirdview, returnM, resultBirdview.size(), cv::INTER_LINEAR, cv::BORDER_CONSTANT);
-
-    return resultBirdview;
+    cv::warpPerspective(src, resultBirdview, M, resultBirdview.size(), cv::INTER_LINEAR, cv::BORDER_CONSTANT);
+    return std::make_pair(resultBirdview, M);
 }

--- a/lane_extraction/src/lane_extraction/utils.cpp
+++ b/lane_extraction/src/lane_extraction/utils.cpp
@@ -1,0 +1,82 @@
+#include "lane_extraction/utils.h"
+#include "opencv2/imgproc.hpp"
+
+LaneParams polyfit(const LanePoints &points, size_t degree, LanePoints *refittedPoints)
+{
+    // solve z = M p (or A x = b) using SVD
+    cv::Mat y(static_cast<int>(points.size()), 1, CV_64F);
+    cv::Mat b(static_cast<int>(points.size()), 1, CV_64F);
+
+    for (size_t i = 0; i < points.size(); i++)
+    {
+        b.at<double>(i) = static_cast<double>(points[i].x);
+        y.at<double>(i) = static_cast<double>(points[i].y);
+    }
+
+    // solve Ax=b
+    cv::Mat A = cv::Mat::ones(points.size(), degree + 1, CV_64F);
+    for (size_t i = 0; i < degree + 1; i++)
+    {
+        cv::pow(y, i, A.colRange(i, i + 1));
+    }
+
+    cv::SVD svd(A);
+    cv::Mat solution;
+    svd.backSubst(b, solution);
+
+    if (refittedPoints)
+    {
+        refittedPoints->clear();
+        cv::Mat newX = A * solution;
+        int x, y;
+        for (int i = 0; i < newX.rows; i++)
+        {
+            x = static_cast<int>(newX.at<double>(i, 0));
+            y = points[i].y;
+            refittedPoints->push_back({x, y});
+        }
+    }
+
+    std::vector<double> params;
+    for (size_t i = 0; i < solution.rows; i++)
+    {
+        params.push_back(solution.at<double>(i, 0));
+    }
+    return params;
+}
+
+void evalPoly(LaneParams &params, LanePoints &points)
+{
+    for (auto &point : points)
+    {
+        point.x = 0;
+        for (size_t i = 0; i < params.size(); i++)
+        {
+            point.x += params[i] * std::pow(point.y, i);
+        }
+    }
+}
+
+cv::Mat birdviewTransformation(const cv::Mat &src, int birdwidth, int birdheight, int skyline, int offsetLeft, int offsetRight, cv::Mat &returnM)
+{
+    int W = src.cols;
+    int H = src.rows;
+
+    cv::Point2f inQuad[4] = {
+        cv::Point(0, skyline),
+        cv::Point(W - 1, skyline),
+        cv::Point(0, H - 1),
+        cv::Point(W - 1, H - 1)};
+
+    cv::Point2f outQuad[4] = {
+        cv::Point(0, skyline),
+        cv::Point(W - 1, skyline),
+        cv::Point(offsetLeft, H - 1),
+        cv::Point(W - offsetRight, H - 1)};
+
+    returnM = cv::getPerspectiveTransform(inQuad, outQuad);
+    cv::Mat resultBirdview(birdheight, birdwidth, src.type());
+    cv::warpPerspective(src, resultBirdview, returnM, resultBirdview.size(), cv::INTER_LINEAR, cv::BORDER_CONSTANT);
+
+    return resultBirdview;
+}

--- a/lane_extraction/src/lane_extraction/window_extractor.cpp
+++ b/lane_extraction/src/lane_extraction/window_extractor.cpp
@@ -44,8 +44,9 @@ void WindowExtractImpl::update()
         return;
     }
 
-    cv::Mat birdTransform;
-    cv::Mat birdview = birdviewTransformation(this->_laneSegImage, birdwidth, birdheight, skyline, offsetLeft, offsetRight, birdTransform);
+    cv::Mat birdview, birdTransform;
+    std::tie(birdview, birdTransform) = birdviewTransformation(this->_laneSegImage, birdwidth, birdheight,
+                                                               skyline, offsetLeft, offsetRight);
 
     birdview(cv::Rect(0, 0, birdview.cols, dropTop)) = cv::Scalar{0};
 

--- a/lane_extraction/src/lane_extraction/window_extractor.cpp
+++ b/lane_extraction/src/lane_extraction/window_extractor.cpp
@@ -44,17 +44,19 @@ void WindowExtractImpl::update()
         return;
     }
 
-    cv::Mat birdview, birdTransform;
-    std::tie(birdview, birdTransform) = birdviewTransformation(this->_laneSegImage, birdwidth, birdheight,
-                                                               skyline, offsetLeft, offsetRight);
-
-    birdview(cv::Rect(0, 0, birdview.cols, dropTop)) = cv::Scalar{0};
-
-    left.update(birdview);
-    right.update(birdview);
+    cv::Mat lineImage = this->_laneSegImage;
+    if (IS_USE_BIRDVIEW)
+    {
+        cv::Mat birdTransform;
+        std::tie(lineImage, birdTransform) = birdviewTransformation(this->_laneSegImage, birdwidth, birdheight,
+                                                                    skyline, offsetLeft, offsetRight);
+        lineImage(cv::Rect(0, 0, lineImage.cols, dropTop)) = cv::Scalar{0};
+    }
+    left.update(lineImage);
+    right.update(lineImage);
 
     cv::Mat debugImage;
-    cv::cvtColor(birdview, debugImage, cv::COLOR_GRAY2BGR);
+    cv::cvtColor(lineImage, debugImage, cv::COLOR_GRAY2BGR);
 
     for (const auto &point : left.getPoints())
     {

--- a/lane_extraction/src/lane_extraction/window_extractor.cpp
+++ b/lane_extraction/src/lane_extraction/window_extractor.cpp
@@ -72,9 +72,9 @@ void WindowExtractImpl::update()
 
 //////////////////////////////////////////////////////////////////////////////
 
-void LaneLine::update(const cv::Mat &birdview)
+void LaneLine::update(const cv::Mat &lineImage)
 {
-    this->birdview = birdview.clone();
+    this->lineImage = lineImage.clone();
 
     if (this->isFound())
     {
@@ -116,7 +116,7 @@ void LaneLine::track()
 
     for (cv::Point2i &center : points)
     {
-        if (updateNewCenter(birdview, center, nullptr))
+        if (updateNewCenter(lineImage, center, nullptr))
         {
             trackingPoints.push_back(center);
         }
@@ -132,7 +132,7 @@ void LaneLine::track()
 
     params = polyfit(trackingPoints, this->POLY_FIT_DEGREE);
     trackingPoints.clear();
-    for (int y = birdview.rows - 1; y > 0; y -= H_TRACKING)
+    for (int y = lineImage.rows - 1; y > 0; y -= H_TRACKING)
     {
         trackingPoints.push_back({0, y});
     }
@@ -204,7 +204,7 @@ bool LaneLine::updateNewCenter(const cv::Mat &region, cv::Point &center, int *co
 bool LaneLine::findBeginPoint(cv::Point &returnPoint) const
 {
     cv::Rect &&regionRect = getDetectBeginPointRegion();
-    const cv::Mat &&region = birdview(regionRect);
+    const cv::Mat &&region = lineImage(regionRect);
 
     for (int center_y = region.rows - 1 - H_TRACKING / 2; center_y > H_TRACKING / 2 + 1; center_y -= H_TRACKING)
     {
@@ -242,7 +242,7 @@ std::vector<cv::Point> LaneLine::findPoints(const cv::Point &beginPoint, int dir
 
     while (true)
     {
-        if (!updateNewCenter(birdview, nextPoint, nullptr))
+        if (!updateNewCenter(lineImage, nextPoint, nullptr))
         {
             break;
         }

--- a/lane_extraction/src/lane_extraction/window_extractor.cpp
+++ b/lane_extraction/src/lane_extraction/window_extractor.cpp
@@ -1,0 +1,259 @@
+#include <cv_bridge/cv_bridge.h>
+#include <array>
+#include <memory>
+#include <algorithm>
+#include <sensor_msgs/Image.h>
+#include <opencv2/opencv.hpp>
+#include "lane_extraction/utils.h"
+#include "lane_extraction/window_extractor.h"
+
+WindowExtractImpl::WindowExtractImpl()
+    : _imageTransport{_nh}
+{
+    std::string lane_seg_topic;
+    ROS_ASSERT(ros::param::get("~sub_laneseg", lane_seg_topic));
+
+    image_transport::TransportHints transport_hint{"compressed"};
+
+    _laneSegSub = _imageTransport.subscribe(
+        lane_seg_topic,
+        10,
+        [this](const sensor_msgs::ImageConstPtr &msg)
+        {
+            cv_bridge::CvImagePtr cv_ptr;
+            try
+            {
+                cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::MONO8);
+                if (!cv_ptr->image.empty())
+                {
+                    this->_laneSegImage = cv_ptr->image.clone();
+                }
+            }
+            catch (cv_bridge::Exception &e)
+            {
+                ROS_ERROR("Could not convert from '%s' to 'mono8'.", msg->encoding.c_str());
+            }
+        },
+        ros::VoidPtr(), transport_hint);
+}
+
+void WindowExtractImpl::update()
+{
+    if (this->_laneSegImage.empty())
+    {
+        return;
+    }
+
+    cv::Mat birdTransform;
+    cv::Mat birdview = birdviewTransformation(this->_laneSegImage, birdwidth, birdheight, skyline, offsetLeft, offsetRight, birdTransform);
+
+    birdview(cv::Rect(0, 0, birdview.cols, dropTop)) = cv::Scalar{0};
+
+    // cv::threshold(birdview, birdview, 127, 255, cv::THRESH_TOZERO);
+
+    left.update(birdview);
+    right.update(birdview);
+
+    cv::Mat debugImage;
+    cv::cvtColor(birdview, debugImage, cv::COLOR_GRAY2BGR);
+
+    for (const auto &point : left.getPoints())
+    {
+        cv::circle(debugImage, point, 3, left.getLaneColor(), -1);
+    }
+
+    for (const auto &point : right.getPoints())
+    {
+        cv::circle(debugImage, point, 3, right.getLaneColor(), -1);
+    }
+
+    cv::imshow("Frame", debugImage);
+    cv::waitKey(1);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+void LaneLine::update(const cv::Mat &birdview)
+{
+    this->birdview = birdview.clone();
+
+    if (this->isFound())
+    {
+        this->track();
+    }
+    else
+    {
+        this->detect();
+    }
+}
+
+void LaneLine::detect()
+{
+    points.clear();
+
+    cv::Point beginPoint;
+    if (findBeginPoint(beginPoint))
+    {
+        std::vector<cv::Point> &&pointsUp = findPoints(beginPoint, 1);
+        std::vector<cv::Point> &&pointsDown = findPoints(beginPoint, -1);
+        std::move(pointsUp.begin(), pointsUp.end(), std::back_inserter(points));
+        std::move(pointsDown.begin(), pointsDown.end(), std::back_inserter(points));
+    }
+
+    if (points.size() < MIN_POINT_DETECT)
+    {
+        // line is lost
+        points.clear();
+        params.clear();
+        return;
+    }
+
+    params = polyfit(this->points, this->POLY_FIT_DEGREE, &(this->points));
+}
+
+void LaneLine::track()
+{
+    LanePoints trackingPoints;
+
+    for (cv::Point2i &center : points)
+    {
+        if (updateNewCenter(birdview, center, nullptr))
+        {
+            trackingPoints.push_back(center);
+        }
+    }
+
+    if (trackingPoints.size() < MIN_POINT_DETECT)
+    {
+        // line is lost
+        points.clear();
+        params.clear();
+        return;
+    }
+
+    params = polyfit(trackingPoints, this->POLY_FIT_DEGREE);
+    trackingPoints.clear();
+    for (int y = birdview.rows - 1; y > 0; y -= H_TRACKING)
+    {
+        trackingPoints.push_back({0, y});
+    }
+
+    evalPoly(params, trackingPoints);
+
+    points = trackingPoints;
+}
+
+bool LaneLine::findPointInWindow(const cv::Mat &roi, cv::Point &outPoint, int &outVal) const
+{
+    size_t maxBinValue = 0;
+    cv::Point maxPoint;
+
+    const int BIN_WIDTH = roi.cols / N_BINS;
+    cv::Mat binImage;
+    for (int bin = 0; bin < N_BINS; bin++)
+    {
+        cv::Rect binROI{bin * BIN_WIDTH, 0, BIN_WIDTH, roi.rows};
+        binImage = roi(binROI);
+
+        size_t binValue = static_cast<size_t>(cv::sum(binImage).val[0]);
+        float binScore = binValue / 255.f / binROI.area();
+
+        if (binScore > 0.1f && binValue > maxBinValue)
+        {
+            maxBinValue = binValue;
+            maxPoint = cv::Point2i{int((bin + 0.5) * BIN_WIDTH), int(binImage.rows / 2)};
+        }
+    }
+
+    if (maxBinValue == 0)
+    {
+        return false;
+    }
+
+    outPoint = maxPoint;
+    outVal = maxBinValue;
+    return true;
+}
+
+bool LaneLine::updateNewCenter(const cv::Mat &region, cv::Point &center, int *const nonZeroValue) const
+{
+    cv::Rect roiTracking{center.x - W_TRACKING / 2, center.y - H_TRACKING / 2, W_TRACKING, H_TRACKING};
+
+    roiTracking &= this->getBirdviewRect();
+
+    if (roiTracking.empty())
+    {
+        return false;
+    }
+
+    const cv::Mat trackingImage = region(roiTracking);
+
+    cv::Point maxPointResult;
+    int value = 0;
+    bool found = findPointInWindow(trackingImage, maxPointResult, value);
+    if (found)
+    {
+        center = roiTracking.tl() + maxPointResult;
+        if (nonZeroValue)
+        {
+            *nonZeroValue = value;
+        }
+    }
+    return found;
+}
+
+bool LaneLine::findBeginPoint(cv::Point &returnPoint) const
+{
+    cv::Rect &&regionRect = getDetectBeginPointRegion();
+    const cv::Mat &&region = birdview(regionRect);
+
+    for (int center_y = region.rows - 1 - H_TRACKING / 2; center_y > H_TRACKING / 2 + 1; center_y -= H_TRACKING)
+    {
+        int maxNonZero = 0;
+        cv::Point maxPoint;
+
+        for (int center_x = W_TRACKING / 2 + 1; center_x < region.cols - W_TRACKING / 2 - 1; center_x += W_TRACKING)
+        {
+            cv::Point center{center_x, center_y};
+            int nonZeroValue = 0;
+            updateNewCenter(region, center, &nonZeroValue);
+            if (nonZeroValue > maxNonZero)
+            {
+                maxNonZero = nonZeroValue;
+                maxPoint = center;
+            }
+        }
+
+        if (maxNonZero > MAX_NON_ZERO_THRESHOLD)
+        {
+            returnPoint = regionRect.tl() + maxPoint;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+std::vector<cv::Point> LaneLine::findPoints(const cv::Point &beginPoint, int direct) const
+{
+    std::vector<cv::Point> result;
+    cv::Point prevPoint = beginPoint;
+    cv::Point nextPoint{beginPoint.x, beginPoint.y + direct * H_TRACKING / 2};
+    cv::Point2f delta;
+
+    while (true)
+    {
+        if (!updateNewCenter(birdview, nextPoint, nullptr))
+        {
+            break;
+        }
+        result.push_back(nextPoint);
+        delta = nextPoint - prevPoint;
+        delta = delta / cv::norm(delta);
+
+        prevPoint = nextPoint;
+        nextPoint.x += static_cast<int>(W_TRACKING * delta.x);
+        nextPoint.y += static_cast<int>(H_TRACKING * delta.y / 2);
+    }
+    return result;
+}

--- a/lane_extraction/src/lane_extraction/window_extractor.cpp
+++ b/lane_extraction/src/lane_extraction/window_extractor.cpp
@@ -49,8 +49,6 @@ void WindowExtractImpl::update()
 
     birdview(cv::Rect(0, 0, birdview.cols, dropTop)) = cv::Scalar{0};
 
-    // cv::threshold(birdview, birdview, 127, 255, cv::THRESH_TOZERO);
-
     left.update(birdview);
     right.update(birdview);
 

--- a/lane_extraction/src/lane_extraction_node.cpp
+++ b/lane_extraction/src/lane_extraction_node.cpp
@@ -1,0 +1,13 @@
+#include <ros/ros.h>
+#include "lane_extraction/lane_extraction.h"
+
+int main(int argc, char **argv)
+{
+    ros::init(argc, argv, "lane_extraction_node");
+    LaneExtractor laneExtractor;
+
+    ROS_INFO("lane_extraction_node starts");
+    laneExtractor.run();
+
+    return 0;
+}


### PR DESCRIPTION
This PR is to track the implementation progress. And will be merge when the below checks are marked:
- [x] Runnable code
- [x] Document code: for librarian functions that might not be changed in the near future. e.g. `utils.h`, `interface.h`
- [x] Document README. At least have the publishing/subscribing section and a command to run
